### PR TITLE
Fix error by removing extra curly brace in Navbar.css

### DIFF
--- a/src/Components/NavBar/NavBar.css
+++ b/src/Components/NavBar/NavBar.css
@@ -243,4 +243,4 @@
         color: white;
     }
 
-}
+


### PR DESCRIPTION
Hi, I have removed and extra curly brace in the NavBar because it was giving error and couldn't see the page.